### PR TITLE
更换了Google 的 s2.favicons 服务在中国大陆可能无法正常访问的问题

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,10 +112,10 @@ addEventListener('fetch', event => {
 function getFavicon(url){
   if(url.match(/https{0,1}:\/\//)){
     //return "https://ui-avatars.com/api/?bold=true&size=36&background=0D8ABC&color=fff&rounded=true&name=" + url.split('//')[1];
-    return "https://www.google.cn/s2/favicons?sz=64&domain_url=" + url;
+    return "https://www.google.com/s2/favicons?sz=64&domain_url=" + url;
   }else{
     //return "https://ui-avatars.com/api/?bold=true&size=36&background=0D8ABC&color=fff&rounded=true&name=" + url;
-    return "https://www.google.cn/s2/favicons?sz=64&domain_url=http://" + url;
+    return "https://www.google.com/s2/favicons?sz=64&domain_url=http://" + url;
   } 
 }
 

--- a/index.js
+++ b/index.js
@@ -109,14 +109,12 @@ addEventListener('fetch', event => {
 /*通过分析链接 实时获取favicon
 * @url 需要分析的Url地址
 */
-function getFavicon(url){
-  if(url.match(/https{0,1}:\/\//)){
-    //return "https://ui-avatars.com/api/?bold=true&size=36&background=0D8ABC&color=fff&rounded=true&name=" + url.split('//')[1];
-    return "https://www.google.com/s2/favicons?sz=64&domain_url=" + url;
-  }else{
-    //return "https://ui-avatars.com/api/?bold=true&size=36&background=0D8ABC&color=fff&rounded=true&name=" + url;
-    return "https://www.google.com/s2/favicons?sz=64&domain_url=http://" + url;
-  } 
+function getFavicon(url) {
+  if (url.match(/^https?:\/\//)) {
+    return "https://favicon.yandex.net/favicon/" + new URL(url).hostname;
+  } else {
+    return "https://favicon.yandex.net/favicon/" + url;
+  }
 }
 
 /** Render Functions


### PR DESCRIPTION
Google 的 s2.favicons 服务在中国大陆可能无法正常访问，修改了通过分析链接实时获取favicon，由原来的

function getFavicon(url){
  if(url.match(/https{0,1}:\/\//)){
    //return "https://ui-avatars.com/api/?bold=true&size=36&background=0D8ABC&color=fff&rounded=true&name=" + url.split('//')[1];
    return "https://www.google.cn/s2/favicons?sz=64&domain_url=" + url;
  }else{
    //return "https://ui-avatars.com/api/?bold=true&size=36&background=0D8ABC&color=fff&rounded=true&name=" + url;
    return "https://www.google.cn/s2/favicons?sz=64&domain_url=http://" + url;
  } 
}

更改为Yandex 提供了一个类似的 Favicon API，在中国大陆通常可以访问：
function getFavicon(url) {
  if (url.match(/^https?:\/\//)) {
    return "https://favicon.yandex.net/favicon/" + new URL(url).hostname;
  } else {
    return "https://favicon.yandex.net/favicon/" + url;
  }
}
示例调用：
console.log(getFavicon("https://baidu.com")); 
// 输出: https://favicon.yandex.net/favicon/baidu.com